### PR TITLE
Add eval working with ash

### DIFF
--- a/discovery.sh
+++ b/discovery.sh
@@ -13,7 +13,7 @@ setup_auto_discovery() {
  log_debug "DEV_NAME=$DEV_NAME"
  log_debug "TOPIC_ROOT=$TOPIC_ROOT"
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/binary_sensor/${DEV_ID}/presence/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/binary_sensor/${DEV_ID}/presence/config -m \
   '{
    "state_topic": "'${TOPIC_ROOT}'/binary_sensor/presence",
    "device": {
@@ -29,7 +29,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_presence"
   }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/generate_keys/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/generate_keys/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/config",
    "device": {
@@ -48,7 +48,7 @@ setup_auto_discovery() {
    "entity_category": "config"
   }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/deploy_key/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/deploy_key/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/config",
    "device": {
@@ -67,7 +67,7 @@ setup_auto_discovery() {
    "entity_category": "config"
   }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/scan_bluetooth/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/scan_bluetooth/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/config",
    "device": {
@@ -86,7 +86,7 @@ setup_auto_discovery() {
    "entity_category": "diagnostic"
   }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/wake/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/wake/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -103,7 +103,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_wake"
   }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/flash-lights/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/flash-lights/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -120,7 +120,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_flash_lights"
   }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/honk/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/honk/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -137,7 +137,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_honk"
   }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/lock/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/lock/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -154,7 +154,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_lock"
   }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/unlock/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/unlock/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -171,7 +171,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_unlock"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/auto-seat-climate/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/auto-seat-climate/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/auto-seat-and-climate",
    "device": {
@@ -188,7 +188,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_auto_seat-climate"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/climate-off/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/climate-off/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -205,7 +205,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_climate-off"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/climate-on/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/climate-on/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -222,7 +222,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_climate-on"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/trunk-open/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/trunk-open/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -239,7 +239,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_trunk-open"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/trunk-close/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/trunk-close/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -256,7 +256,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_trunk-close"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/frunk-open/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/frunk-open/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -273,7 +273,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_frunk-open"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/charging-start/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charging-start/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -290,7 +290,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_charging-start"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/charging-stop/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charging-stop/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -307,7 +307,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_charging-stop"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/charge-port-open/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charge-port-open/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -324,7 +324,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_charge-port-open"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/charge-port-close/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charge-port-close/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -341,7 +341,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_charge-port-close"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/windows-close/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/windows-close/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -358,7 +358,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_windows-close"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/${DEV_ID}/windows-vent/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/windows-vent/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
@@ -375,7 +375,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_windows-vent"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/number/${DEV_ID}/charging-set-amps/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/charging-set-amps/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/charging-amps",
    "device": {
@@ -396,7 +396,7 @@ setup_auto_discovery() {
    "icon": "mdi:current-ac"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/number/${DEV_ID}/charging-set-limit/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/charging-set-limit/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/charging-set-limit",
    "device": {
@@ -417,7 +417,7 @@ setup_auto_discovery() {
    "icon": "mdi:battery-90"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/number/${DEV_ID}/climate-temp/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/climate-temp/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/climate-set-temp",
    "device": {
@@ -438,7 +438,7 @@ setup_auto_discovery() {
    "icon": "mdi:temperature"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/switch/${DEV_ID}/sw-heater/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/sw-heater/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/sw-heater",
    "device": {
@@ -455,7 +455,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_sw_heater"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/switch/${DEV_ID}/sentry-mode/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/sentry-mode/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/sentry-mode",
    "device": {
@@ -472,7 +472,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_sentry-mode"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/select/${DEV_ID}/heated_seat_left/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/select/${DEV_ID}/heated_seat_left/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/heated_seat_left",
    "device": {
@@ -490,7 +490,7 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_heated_seat_left"
    }'
 
- mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/select/${DEV_ID}/heated_seat_right/config -m \
+ eval $MOSQUITTO_PUB_BASE -t homeassistant/select/${DEV_ID}/heated_seat_right/config -m \
   '{
    "command_topic": "'${TOPIC_ROOT}'/heated_seat_right",
    "device": {

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -2,7 +2,7 @@
 
 listen_to_mqtt() {
  # log_info "Listening to MQTT"
- mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" --nodelay -t tesla_ble/+/+ -F "%t %p" -E -c -i tesla_ble_mqtt -q 1 \
+ eval $MOSQUITTO_SUB_BASE --nodelay -t tesla_ble/+/+ -F "%t %p" -E -c -i tesla_ble_mqtt -q 1 \
       | while read -r payload
   do
    topic=${payload%% *}
@@ -143,7 +143,7 @@ listen_to_mqtt() {
 }
 
 listen_for_HA_start() {
- mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" --nodelay -t homeassistant/status -F "%t %p" | while read -r payload
+ $MOSQUITTO_SUB_BASE --nodelay -t homeassistant/status -F "%t %p" | while read -r payload
   do
    topic=$(echo "$payload" | cut -d ' ' -f 1)
    msg=$(echo "$payload" | cut -d ' ' -f 2-)

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -143,7 +143,7 @@ listen_to_mqtt() {
 }
 
 listen_for_HA_start() {
- $MOSQUITTO_SUB_BASE --nodelay -t homeassistant/status -F "%t %p" | while read -r payload
+ eval $MOSQUITTO_SUB_BASE --nodelay -t homeassistant/status -F "%t %p" | while read -r payload
   do
    topic=$(echo "$payload" | cut -d ' ' -f 1)
    msg=$(echo "$payload" | cut -d ' ' -f 2-)

--- a/run.sh
+++ b/run.sh
@@ -34,8 +34,8 @@ if [ -n "${HASSIO_TOKEN:-}" ]; then
   export DEBUG="$(bashio::config 'debug')"
 fi
 
-export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u \"${MQTT_USER}\" -P \"${MQTT_PWD}\""
-export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -u \"${MQTT_USER}\" -P \"${MQTT_PWD}\""
+export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u '${MQTT_USER}' -P '${MQTT_PWD}'"
+export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -u '${MQTT_USER}' -P '${MQTT_PWD}'"
 
 ### HANDLE CONFIG CHANGE #############################################################################################
 if [ -f /share/tesla_ble_mqtt/private.pem ]; then
@@ -93,9 +93,9 @@ log_info "Listening for Home Assistant Start (in background)"
 listen_for_HA_start &
 
 log_info "Discarding any unread MQTT messages"
-mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -E -i tesla_ble_mqtt -t tesla_ble_mqtt/$TESLA_VIN1/+
-mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -E -i tesla_ble_mqtt -t tesla_ble_mqtt/$TESLA_VIN2/+
-mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -E -i tesla_ble_mqtt -t tesla_ble_mqtt/$TESLA_VIN3/+
+eval $MOSQUITTO_SUB -E -i tesla_ble_mqtt -t tesla_ble_mqtt/$TESLA_VIN1/+
+eval $MOSQUITTO_SUB -E -i tesla_ble_mqtt -t tesla_ble_mqtt/$TESLA_VIN2/+
+eval $MOSQUITTO_SUB -E -i tesla_ble_mqtt -t tesla_ble_mqtt/$TESLA_VIN3/+
 
 ### START MAIN PROGRAM LOOP ######################################################################################
 counter=0

--- a/subroutines.sh
+++ b/subroutines.sh
@@ -37,10 +37,10 @@ listen_to_ble() {
  set -e
  if [ $EXIT_STATUS -eq 0 ]; then
    echo "$BLE_MAC1 presence detected"
-   mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" --nodelay -t tesla_ble_mqtt/$TESLA_VIN1/binary_sensor/presence -m ON
+   eval $MOSQUITTO_SUB --nodelay -t tesla_ble_mqtt/$TESLA_VIN1/binary_sensor/presence -m ON
  else
    echo "$BLE_MAC1 presence not detected"
-   mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" --nodelay -t tesla_ble_mqtt/$TESLA_VIN1/binary_sensor/presence -m OFF
+   eval $MOSQUITTO_SUB --nodelay -t tesla_ble_mqtt/$TESLA_VIN1/binary_sensor/presence -m OFF
  fi
 }
 
@@ -73,34 +73,34 @@ scan_bluetooth(){
 
 delete_legacies(){
   log_notice "Deleting Legacy MQTT Topics"
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/switch/tesla_ble/sw-heater/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/switch/tesla_ble/sentry-mode/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/select/tesla_ble/heated_seat_left/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/select/tesla_ble/heated_seat_right/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/binary_sensor/tesla_ble/presence/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/number/tesla_ble/charging-set-amps/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/number/tesla_ble/charging-set-limit/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/number/tesla_ble/climate-temp/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/generate_keys/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/deploy_key/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/scan_bluetooth/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/wake/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/flash-lights/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/honk/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/lock/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/unlock/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/auto-seat-climate/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/climate-on/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/climate-off/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/trunk-open/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/trunk-close/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/frunk-open/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/charging-start/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/charging-stop/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/charge-port-open/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/charge-port-close/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/windows-close/config -n
-  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "${MQTT_USER}" -P "${MQTT_PWD}" -t homeassistant/button/tesla_ble/windows-vent/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/switch/tesla_ble/sw-heater/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/switch/tesla_ble/sentry-mode/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/select/tesla_ble/heated_seat_left/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/select/tesla_ble/heated_seat_right/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/binary_sensor/tesla_ble/presence/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/number/tesla_ble/charging-set-amps/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/number/tesla_ble/charging-set-limit/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/number/tesla_ble/climate-temp/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/generate_keys/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/deploy_key/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/scan_bluetooth/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/wake/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/flash-lights/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/honk/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/lock/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/unlock/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/auto-seat-climate/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/climate-on/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/climate-off/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/trunk-open/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/trunk-close/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/frunk-open/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/charging-start/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/charging-stop/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/charge-port-open/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/charge-port-close/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/windows-close/config -n
+  eval $MOSQUITTO_SUB -t homeassistant/button/tesla_ble/windows-vent/config -n
 
   if [ -f /share/tesla_ble_mqtt/private.pem ]; then
     log_notice "Renaming legacy keys"


### PR DESCRIPTION
Hopefully the working example below with sh/ash doesn't make anyone nervous anymore:

```
# ash
# cat init-var.sh
export MQTT_IP=mqtt.xxxxxx.com
export MQTT_PORT=1883
export MQTT_USER=tesla-ble
export MQTT_PWD="a password; with & and "
# . ./init-var.sh
# cat mosquitto_pub
echo "\"$1\""
echo "\"$2\""
echo "\"$3\""
echo "\"$4\""
echo "\"$5\""
echo "\"$6\""
echo "\"$7\""
echo "\"$8\""
# export MOSQUITTO_PUB_BASE="./mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u '${MQTT_USER}' -P '${
MQTT_PWD}'"
#
# eval $MOSQUITTO_PUB_BASE
"-h"
"mqtt.xxxxxx.com"
"-p"
"1883"
"-u"
"tesla-ble"
"-P"
"a password; with & and "
```