### PR TITLE
Adjust logging

### DIFF
--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -14,7 +14,6 @@ listen_to_mqtt() {
 
    case $cmnd in
     config)
-     log_info "Configuration $msg requested"
 
      case $msg in
       generate_keys)
@@ -46,7 +45,6 @@ listen_to_mqtt() {
 	;;
 
     command)
-     log_info "Command $msg requested"
      case $msg in
        wake)
         log_notice "Waking Car"
@@ -102,7 +100,6 @@ listen_to_mqtt() {
 	;;
 	
     charging-amps)
-     log_info "Set Charging Amps to $msg requested"
      # https://github.com/iainbullock/tesla_ble_mqtt_docker/issues/4
      if [ $msg -gt 4 ]; then
      log_notice "Set amps"
@@ -117,23 +114,18 @@ listen_to_mqtt() {
 	;;
 	
     auto-seat-and-climate)
-     log_notice "Start Auto Seat and Climate"
      send_command $vin "auto-seat-and-climate LR on";;
 
     charging-set-limit)
-     log_notice "Set Charging Limit to $msg"
      send_command $vin "charging-set-limit $msg";;
 
     climate-set-temp)
-     log_notice "Set Climate Temp to $msg"
      send_command $vin "climate-set-temp ${msg}C";;
 
     heated_seat_left)
-     log_notice "Set Seat heater to front-left $msg"
      send_command $vin "seat-heater front-left $msg";;
 
     heated_seat_right)
-     log_notice "Set Seat heater to front-right $msg"
      send_command $vin "seat-heater front-right $msg";;
 
     *)

--- a/subroutines.sh
+++ b/subroutines.sh
@@ -19,7 +19,7 @@ send_command() {
 	 break
 	else
      log_error "tesla-control send command failed exit status $EXIT_STATUS."
-	 log_info $message
+	 log_error $message
 	 log_notice "Retrying in $SEND_CMD_RETRY_DELAY seconds"
 	fi
     sleep $SEND_CMD_RETRY_DELAY

--- a/subroutines.sh
+++ b/subroutines.sh
@@ -14,8 +14,8 @@ send_command() {
     break
   else
 	if [[ $message == *"Failed to execute command: car could not execute command"* ]]; then
-	 log_error $message
-	 log_notice "Skipping command $@ to vin $vin"
+	 log_warning $message
+	 log_warning "Skipping command $@ to vin $vin"
 	 break
 	else
      log_error "tesla-control send command failed exit status $EXIT_STATUS."


### PR DESCRIPTION
Proposal to adjust the (too verbose) logging:
- Consistently warn if car answers on command but cannot execute
- Reduce logging in `listen_to_mqtt.sh`: when pushing a button in MQTT, we get 3 logs: "Received MQTT message...", "Waking car" (eg.), "Sending command $@ to vin $vin, attempt $i/5", then the status. I feel this is too much 