### PR TITLE
Fix MOSQUITTO_ & revert discovery.sh

### DIFF
--- a/discovery.sh
+++ b/discovery.sh
@@ -15,8 +15,7 @@ setup_auto_discovery() {
  log_debug "DEV_NAME=$DEV_NAME"
  log_debug "TOPIC_ROOT=$TOPIC_ROOT"
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/binary_sensor/${DEV_ID}/presence/config -m \
-  '{
+  echo '{
    "state_topic": "'${TOPIC_ROOT}'/binary_sensor/presence",
    "device": {
     "identifiers": [
@@ -30,10 +29,9 @@ setup_auto_discovery() {
    "name": "Presence",
    "unique_id": "'${DEV_ID}'_presence",
    "sw_version": "'${SW_VERSION}'"
-  }'
+  }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/binary_sensor/${DEV_ID}/presence/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/generate_keys/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/config",
    "device": {
     "identifiers": [
@@ -50,10 +48,9 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_generate_keys",
    "entity_category": "config",
    "sw_version": "'${SW_VERSION}'"
-  }'
+  }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/generate_keys/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/deploy_key/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/config",
    "device": {
     "identifiers": [
@@ -70,10 +67,9 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_deploy_key",
    "entity_category": "config",
    "sw_version": "'${SW_VERSION}'"
-  }'
+  }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/deploy_key/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/scan_bluetooth/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/config",
    "device": {
     "identifiers": [
@@ -90,10 +86,9 @@ setup_auto_discovery() {
    "unique_id": "'${DEV_ID}'_scan_bluetooth",
    "entity_category": "diagnostic",
    "sw_version": "'${SW_VERSION}'"
-  }'
+  }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/scan_bluetooth/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/wake/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -108,10 +103,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_wake",
    "sw_version": "'${SW_VERSION}'"
-  }'
+  }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/wake/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/flash-lights/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -126,10 +120,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_flash_lights",
    "sw_version": "'${SW_VERSION}'"
-  }'
+  }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/flash-lights/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/honk/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -144,10 +137,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_honk",
    "sw_version": "'${SW_VERSION}'"
-  }'
+  }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/honk/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/lock/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -162,10 +154,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_lock",
    "sw_version": "'${SW_VERSION}'"
-  }'
+  }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/lock/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/unlock/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -180,10 +171,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_unlock",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/unlock/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/auto-seat-climate/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/auto-seat-and-climate",
    "device": {
     "identifiers": [
@@ -198,10 +188,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_auto_seat-climate",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/auto-seat-climate/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/climate-off/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -216,10 +205,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_climate-off",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/climate-off/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/climate-on/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -234,10 +222,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_climate-on",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/climate-on/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/trunk-open/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -252,10 +239,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_trunk-open",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/trunk-open/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/trunk-close/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -270,10 +256,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_trunk-close",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/trunk-close/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/frunk-open/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -288,10 +273,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_frunk-open",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/frunk-open/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charging-start/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -306,10 +290,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_charging-start",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charging-start/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charging-stop/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -324,10 +307,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_charging-stop",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charging-stop/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charge-port-open/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -342,10 +324,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_charge-port-open",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charge-port-open/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charge-port-close/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -360,10 +341,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_charge-port-close",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/charge-port-close/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/windows-close/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -378,10 +358,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_windows-close",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/windows-close/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/windows-vent/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/command",
    "device": {
     "identifiers": [
@@ -396,10 +375,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_windows-vent",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/button/${DEV_ID}/windows-vent/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/charging-set-amps/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/charging-amps",
    "device": {
     "identifiers": [
@@ -418,10 +396,9 @@ setup_auto_discovery() {
    "qos": 1,
    "icon": "mdi:current-ac",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/charging-set-amps/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/charging-set-amps-override/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/charging-amps-override",
    "device": {
     "identifiers": [
@@ -441,10 +418,9 @@ setup_auto_discovery() {
    "icon": "mdi:current-ac",
    "entity_category": "diagnostic",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/charging-set-amps-override/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/charging-set-limit/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/charging-set-limit",
    "device": {
     "identifiers": [
@@ -463,10 +439,9 @@ setup_auto_discovery() {
    "qos": 1,
    "icon": "mdi:battery-90",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/charging-set-limit/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/climate-temp/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/climate-set-temp",
    "device": {
     "identifiers": [
@@ -485,10 +460,9 @@ setup_auto_discovery() {
    "qos": 1,
    "icon": "mdi:temperature",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/climate-temp/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/sw-heater/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/sw-heater",
    "device": {
     "identifiers": [
@@ -503,10 +477,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_sw_heater",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/sw-heater/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/sentry-mode/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/sentry-mode",
    "device": {
     "identifiers": [
@@ -521,10 +494,9 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "'${DEV_ID}'_sentry-mode",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/sentry-mode/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/select/${DEV_ID}/heated_seat_left/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/heated_seat_left",
    "device": {
     "identifiers": [
@@ -540,10 +512,9 @@ setup_auto_discovery() {
    "icon": "mdi:car-seat-heater",
    "unique_id": "'${DEV_ID}'_heated_seat_left",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/select/${DEV_ID}/heated_seat_left/config -l
 
- eval $MOSQUITTO_PUB_BASE -t homeassistant/select/${DEV_ID}/heated_seat_right/config -m \
-  '{
+  echo '{
    "command_topic": "'${TOPIC_ROOT}'/heated_seat_right",
    "device": {
     "identifiers": [
@@ -559,6 +530,6 @@ setup_auto_discovery() {
    "icon": "mdi:car-seat-heater",
    "unique_id": "'${DEV_ID}'_heated_seat_right",
    "sw_version": "'${SW_VERSION}'"
-   }'
+   }' | eval $MOSQUITTO_PUB_BASE -t homeassistant/select/${DEV_ID}/heated_seat_right/config -l
 
- }
+}

--- a/run.sh
+++ b/run.sh
@@ -71,8 +71,8 @@ export BLECTL_FILE_INPUT=${BLECTL_FILE_INPUT:-}
 # MQTT clients anonymous or authentication mode
 if [ ! -z ${MQTT_USERNAME} ]; then
   log_debug "Setting up MQTT clients with authentication is on; MQTT_USERNAME=$MQTT_USERNAME"
-  export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_SERVER -p $MQTT_PORT -u \"${MQTT_USERNAME}\" -P \"${MQTT_PASSWORD}\""
-  export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_SERVER -p $MQTT_PORT -u \"${MQTT_USERNAME}\" -P \"${MQTT_PASSWORD}\""
+  export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_SERVER -p $MQTT_PORT -u '${MQTT_USERNAME}' -P '${MQTT_PASSWORD}'"
+  export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_SERVER -p $MQTT_PORT -u '${MQTT_USERNAME}' -P '${MQTT_PASSWORD}'"
 else
   log_notice "Setting up MQTT clients in anonymous"
   export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_SERVER -p $MQTT_PORT"


### PR DESCRIPTION
1. In `multi-cars` we reverted `discovery.sh` with a version that isn't `eval MOSQUITTO_` friendly.  The one in here is the one we need.
2. Somehow the definition of MOSQUITTO_(PUB|SUB)_BASE was changed, most likely due to a bad merge / conflict fix.