### PR TITLE
Issue 31 docker

### DIFF
--- a/discovery.sh
+++ b/discovery.sh
@@ -465,7 +465,7 @@ setup_auto_discovery() {
    }' | sed ':a;N;$!ba;s/\n//g' | eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/climate-temp/config -l
 
   echo '{
-   "command_topic": "'${TOPIC_ROOT}'/sw-heater",
+   "command_topic": "'${TOPIC_ROOT}'/steering-wheel-heater",
    "device": {
     "identifiers": [
     "'${DEV_ID}'"
@@ -478,7 +478,7 @@ setup_auto_discovery() {
    "name": "Steering Wheel Heater",
    "device_class": "switch",
    "qos": 1,
-   "unique_id": "'${DEV_ID}'_sw-heater"
+   "unique_id": "'${DEV_ID}'_steering-wheel-heater"
    }' | sed ':a;N;$!ba;s/\n//g' | eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/sw-heater/config -l
 
   echo '{

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -184,13 +184,13 @@ listen_to_mqtt() {
         send_command $vin "seat-heater front-right $msg"
         ;;
 
-      sw-heater)
-	    msg_lower=`echo "$msg" | tr '[:upper:]' '[:lower:]'`
-        send_command $vin "sw-heater $msg_lower"
+      steering-wheel-heater)
+	    msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
+        send_command $vin "steering-wheel-heater $msg_lower"
         ;;
 
       sentry-mode)
-	    msg_lower=`echo "$msg" | tr '[:upper:]' '[:lower:]'`
+	    msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
         send_command $vin "sentry-mode $msg_lower"
         ;;
 

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -185,12 +185,12 @@ listen_to_mqtt() {
         ;;
 
       steering-wheel-heater)
-	    msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
+        msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
         send_command $vin "steering-wheel-heater $msg_lower"
         ;;
 
       sentry-mode)
-	    msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
+        msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
         send_command $vin "sentry-mode $msg_lower"
         ;;
 

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -188,6 +188,11 @@ listen_to_mqtt() {
         send_command $vin "sw-heater $msg"
         ;;
 
+      sentry-mode)
+	    msg_lower=`echo "$msg" | tr '[:upper:]' '[:lower:]'`
+        send_command $vin "sentry-mode $msg_lower"
+        ;;
+
       *)
         log_error "Invalid request; topic:$topic vin:$vin msg:$msg"
         ;;

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -185,7 +185,8 @@ listen_to_mqtt() {
         ;;
 
       sw-heater)
-        send_command $vin "sw-heater $msg"
+	    msg_lower=`echo "$msg" | tr '[:upper:]' '[:lower:]'`
+        send_command $vin "sw-heater $msg_lower"
         ;;
 
       sentry-mode)


### PR DESCRIPTION
https://github.com/tesla-local-control/tesla_ble_mqtt_docker/issues/31

Two corrections:
- the command `sentry-mode` was non existing in `listen_to_mqtt.sh`
- mqtt sends uppercase ON/OFF, which is not parsed by tesla-control --> forced lowercase in `listen_to_mqtt.sh`