### PR TITLE
Smarter device cards panel (stage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - NEW Feature: Added "debug" entity which sends only one charge amps command: Issue [#19](https://github.com/tesla-local-control/tesla_ble_mqtt_core/issues/19)
 - NEW Setting: BLE Proximity Detection TTL (Detection is on by default; set to 0 to disable)
 - NEW Setting: Presence Detection Loop Delay (how often to check the presence of your car(s))
-- NEW Setting: Toggle to enable/disable HA backend (Standalone version only)
+- NEW Setting: Toggle to enable/disable Home Assistant Features (Standalone version only)
 - CHG: Improved presence detection reliability (using car's MAC addr and BLE Local Name)
 - CHG: Support bashio::log w/ timestamp (HA add-on)
 - CHG: Reduce logging; Improved colors consistency; More to be removed once code is considered stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,24 @@
 
 ## 0.0.11
 
-- BREAKING CHANGES: Keep a backup of your VIN & MAC Addr
+### Breaking change & Upgrade Instruction
+- **BREAKING CHANGE - save config before update**: Now supports **list** of VINS and MAC addresses. You will need to adjust configuration. Existing **entities** from v0.0.10f will not be affected.
+- Cut & Paste your current vin to vin_list
+- Cut & Paste your current mac_addr to mac_addr_list
 
+### Changed
 - NEW Feature: Support for unlimited cars (VINs + MAC Addrs)
 - NEW Feature: Added a TTL for car presence, when gone the sensor in HA stays ON until the TTL expires
+- NEW Feature: Added "debug" entity which sends only one charge amps command: Issue [#19](https://github.com/tesla-local-control/tesla_ble_mqtt_core/issues/19)
 - NEW Setting: BLE Proximity Detection TTL (Detection is on by default; set to 0 to disable)
 - NEW Setting: Presence Detection Loop Delay (how often to check the presence of your car(s))
 - NEW Setting: Toggle to enable/disable HA backend (Standalone version only)
-- CHG : Support bashio::log w/ timestamp (HA add-on)
-- CHG : Reduce logging; More to be removed once code is considered stable
-- CHD : Improved presence detection using car's MAC addr and BLE Local Name
-- WARNING : [BLE device overheating](https://github.com/tesla-local-control/tesla-local-control-addon/issues/27) causing performance issues
+- CHG: Improved presence detection reliability (using car's MAC addr and BLE Local Name)
+- CHG: Support bashio::log w/ timestamp (HA add-on)
+- CHG: Reduce logging; Improved colors consistency; More to be removed once code is considered stable
+- CHG: Add bluez-deprecated pkg (ciptool hciattach hciconfig hcidump hcitool meshctl rfcomm sdptool)
+- WARNING: [BLE device possible overheating](https://github.com/tesla-local-control/tesla-local-control-addon/issues/27) causing performance issues
+
 
 ## 0.0.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
-## 0.0.11
+## 0.1.0
 
 ### Breaking change & Upgrade Instruction
 - **BREAKING CHANGE - save config before update**: Now supports **list** of VINS and MAC addresses. You will need to adjust configuration. Existing **entities** from v0.0.10f will not be affected.

--- a/discovery.sh
+++ b/discovery.sh
@@ -43,12 +43,30 @@ function setupHADevicePanelCardsMain() {
   log_debug "setupHADevicePanelCardsMain() entering vin:$vin"
   configHADeviceEnvVars $vin
 
-  # Setup all device's cards
-  setupHADevicePresenceSensor $vin
-  setupHADeviceDeployKeyButton $vin
-  setupHADeviceGenerateKeysButton $vin
-  setupHADeviceControlsCard $vin
-  setupHADeviceScanBLElnButton $vin
+  keysDir=/share/tesla_ble_mqtt
+
+  # If detection is enable, show presence
+  if [ $PRESENCE_DETECTION_TTL -gt 0 ] && [ -n "$BLE_MAC_LIST" ]; then
+    log_debug "setupHADevicePanelCardsMain() vin:$vin presence detection enable"
+    setupHADevicePresenceSensor $vin
+  fi
+
+  # Newly added car?
+  if [ ! -f $keysDir/${vin}_private.pem ] && [ ! -f $keysDir/${vin}_public.pem ]; then
+
+    log_debug "setupHADevicePanelCardsMain() vin:$vin newly added car, adding Generate Key menu"
+    # Show button to Generate Keys
+    setupHADeviceGenerateKeysButton $vin
+
+    # listen_to_mqtt call setupHADeviceDeployKeyButton once the keys are generated
+
+  else
+    log_debug "setupHADevicePanelCardsMain() vin:$vin old car"
+    setupHADeviceDeployKeyButton $vin
+    setupHADeviceGenerateKeysButton $vin
+    setupHADeviceControlsCard $vin
+    setupHADeviceScanBLElnButton $vin
+  fi
 
   log_debug "setupHADevicePanelCardsMain() leaving vin:$vin"
 

--- a/discovery.sh
+++ b/discovery.sh
@@ -465,7 +465,7 @@ setup_auto_discovery() {
    }' | sed ':a;N;$!ba;s/\n//g' | eval $MOSQUITTO_PUB_BASE -t homeassistant/number/${DEV_ID}/climate-temp/config -l
 
   echo '{
-   "command_topic": "'${TOPIC_ROOT}'/sw-heater",
+   "command_topic": "'${TOPIC_ROOT}'/steering-wheel-heater",
    "device": {
     "identifiers": [
     "'${DEV_ID}'"
@@ -478,8 +478,8 @@ setup_auto_discovery() {
    "name": "Steering Wheel Heater",
    "device_class": "switch",
    "qos": 1,
-   "unique_id": "'${DEV_ID}'_sw-heater"
-   }' | sed ':a;N;$!ba;s/\n//g' | eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/sw-heater/config -l
+   "unique_id": "'${DEV_ID}'_steering-wheel-heater"
+   }' | sed ':a;N;$!ba;s/\n//g' | eval $MOSQUITTO_PUB_BASE -t homeassistant/switch/${DEV_ID}/steering-wheel-heater/config -l
 
   echo '{
    "command_topic": "'${TOPIC_ROOT}'/sentry-mode",

--- a/discovery.sh
+++ b/discovery.sh
@@ -52,19 +52,25 @@ function setupHADevicePanelCardsMain() {
   fi
 
   # Newly added car?
-  if [ ! -f $keysDir/${vin}_private.pem ] && [ ! -f $keysDir/${vin}_public.pem ]; then
+  if [ $keysDir/${vin}_pubkey_accepted ]; then
+    log_debug "setupHADevicePanelCardsMain() pubkey deployed vin:$vin"
+    setupHADeviceDeployKeyButton $vin
+    setupHADeviceGenerateKeysButton $vin
+    setupHADeviceControlsCard $vin
+    setupHADeviceScanBLElnButton $vin
+  elif [ ! -f $keysDir/${vin}_private.pem ] && [ ! -f $keysDir/${vin}_public.pem ]; then
 
-    log_debug "setupHADevicePanelCardsMain() vin:$vin newly added car, adding Generate Key menu"
+    log_debug "setupHADevicePanelCardsMain() vin:$vin newly added car, adding Generate Key button"
     # Show button to Generate Keys
     setupHADeviceGenerateKeysButton $vin
+    setupHADeviceScanBLElnButton $vin
 
     # listen_to_mqtt call setupHADeviceDeployKeyButton once the keys are generated
 
   else
-    log_debug "setupHADevicePanelCardsMain() vin:$vin old car"
+    log_debug "setupHADevicePanelCardsMain() new car but pubkey not deployed yet vin:$vin"
     setupHADeviceDeployKeyButton $vin
     setupHADeviceGenerateKeysButton $vin
-    setupHADeviceControlsCard $vin
     setupHADeviceScanBLElnButton $vin
   fi
 

--- a/discovery.sh
+++ b/discovery.sh
@@ -52,7 +52,7 @@ function setupHADevicePanelCardsMain() {
   fi
 
   # Newly added car?
-  if [ $keysDir/${vin}_pubkey_accepted ]; then
+  if [ -f $keysDir/${vin}_pubkey_accepted ]; then
     log_debug "setupHADevicePanelCardsMain() pubkey deployed vin:$vin"
     setupHADeviceDeployKeyButton $vin
     setupHADeviceGenerateKeysButton $vin
@@ -669,7 +669,6 @@ function setupHADeviceScanBLElnButton() {
   log_debug "setupHADeviceScanBLElnButton() leaving vin:$vin"
 
 }
-
 
 ###
 ##

--- a/discovery.sh
+++ b/discovery.sh
@@ -53,14 +53,14 @@ function setupHADevicePanelCardsMain() {
 
   # Newly added car?
   if [ -f $keysDir/${vin}_pubkey_accepted ]; then
-    log_debug "setupHADevicePanelCardsMain() pubkey deployed vin:$vin"
+    log_debug "setupHADevicePanelCardsMain() found vehicle with pubkey deployed vin:$vin"
     setupHADeviceDeployKeyButton $vin
     setupHADeviceGenerateKeysButton $vin
     setupHADeviceControlsCard $vin
     setupHADeviceScanBLElnButton $vin
   elif [ ! -f $keysDir/${vin}_private.pem ] && [ ! -f $keysDir/${vin}_public.pem ]; then
 
-    log_debug "setupHADevicePanelCardsMain() vin:$vin newly added car, adding Generate Key button"
+    log_debug "setupHADevicePanelCardsMain() found new vehicle, need to generate keys set vin:$vin"
     # Show button to Generate Keys
     setupHADeviceGenerateKeysButton $vin
     setupHADeviceScanBLElnButton $vin
@@ -68,7 +68,7 @@ function setupHADevicePanelCardsMain() {
     # listen_to_mqtt call setupHADeviceDeployKeyButton once the keys are generated
 
   else
-    log_debug "setupHADevicePanelCardsMain() new car but pubkey not deployed yet vin:$vin"
+    log_debug "setupHADevicePanelCardsMain() found new vehicle, need to deploy public key vin:$vin"
     setupHADeviceDeployKeyButton $vin
     setupHADeviceGenerateKeysButton $vin
     setupHADeviceScanBLElnButton $vin

--- a/discovery.sh
+++ b/discovery.sh
@@ -11,7 +11,6 @@ setup_auto_discovery() {
   DEV_NAME=Tesla_BLE_${vin}
 
   TOPIC_ROOT=tesla_ble/${vin}
-  SW_VERSION=0.0.10f
 
   log_debug "DEV_ID=$DEV_ID"
   log_debug "DEV_NAME=$DEV_NAME"

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,73 @@
+#!/bin/ash
+#
+# shellcheck shell=dash
+#
+
+### LOAD LIBRARIES (FUNCTIONS & ENVIRONMENT ) #################################
+echo "Loading libraries (functions & environment)..."
+for fSource in "version.h \
+  product.sh \
+  mqtt.sh \
+  discovery.sh \
+  listen_to_mqtt.sh \
+  subroutines.sh \
+  tesla.sh"; do
+
+  if [ -f $fSource ]; then
+    [ $DEBUG == "true" ] && echo "$DATELOG Loading /app/$fSource"
+    . /app/$fSource
+  else
+    echo "Fatal error; file not found $fSource"
+    exit 10
+  fi
+done
+### END Source all required files
+
+
+# If empty string, initialize w/ default value - Required for add-on and Docker standalone
+export BLE_CMD_RETRY_DELAY=${BLE_CMD_RETRY_DELAY:-5}
+export BLECTL_FILE_INPUT=${BLECTL_FILE_INPUT:-}
+export ENABLE_HA_FEATURES=${ENABLE_HA_FEATURES:-true}
+export PRESENCE_DETECTION_LOOP_DELAY=${PRESENCE_DETECTION_LOOP_DELAY:-120}
+export PRESENCE_DETECTION_TTL=${PRESENCE_DETECTION_TTL:-240}
+
+export BLE_LN_REGEX='S[0-9A-Fa-f]{16}C'
+export MAC_REGEX='([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})'
+export VIN_REGEX='[A-HJ-NPR-Z0-9]{17}'
+
+
+### LOG CONFIG VARS ###########################################################
+log_info "Configuration Options are:
+  BLE_CMD_RETRY_DELAY=$BLE_CMD_RETRY_DELAY
+  BLE_MAC_LIST=$BLE_MAC_LIST
+  DEBUG=$DEBUG
+  MQTT_SERVER=$MQTT_SERVER
+  MQTT_PORT=$MQTT_PORT
+  MQTT_PASSWORD=Not Shown
+  MQTT_USERNAME=$MQTT_USERNAME
+  PRESENCE_DETECTION_LOOP_DELAY=$PRESENCE_DETECTION_LOOP_DELAY
+  PRESENCE_DETECTION_TTL=$PRESENCE_DETECTION_TTL
+  VIN_LIST=$VIN_LIST"
+
+[ -n "$ENABLE_HA_FEATURES" ] && log_info "  ENABLE_HA_FEATURES=$ENABLE_HA_FEATURES"
+[ -n "$BLECTL_FILE_INPUT" ] && log_info "  BLECTL_FILE_INPUT=$BLECTL_FILE_INPUT"
+
+
+### SETUP DIRECTORY ###########################################################
+if [ ! -d /share/tesla_ble_mqtt ]; then
+  log_info "Creating directory /share/tesla_ble_mqtt"
+  mkdir -p /share/tesla_ble_mqtt
+else
+  log_debug "/share/tesla_ble_mqtt already exists"
+fi
+
+
+### MQTT clients anonymous or authentication mode #############################
+if [ -n "$MQTT_USERNAME" ]; then
+  log_notice "Setting up MQTT clients with authentication"
+  export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_SERVER -p $MQTT_PORT -u '${MQTT_USERNAME}' -P '${MQTT_PASSWORD}'"
+  export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_SERVER -p $MQTT_PORT -u '${MQTT_USERNAME}' -P '${MQTT_PASSWORD}'"
+else
+  log_notice "Setting up MQTT clients using anonymous mode"
+  export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_SERVER -p $MQTT_PORT"
+  export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_SERVER -p $MQTT_PORT"

--- a/env.sh
+++ b/env.sh
@@ -5,16 +5,17 @@
 
 ### LOAD LIBRARIES (FUNCTIONS & ENVIRONMENT ) #################################
 echo "Loading libraries (functions & environment)..."
-for fSource in "version.h \
+for fSource in version.h \
   product.sh \
   mqtt.sh \
   discovery.sh \
   listen_to_mqtt.sh \
   subroutines.sh \
-  tesla.sh"; do
+  tesla.sh; do
 
   if [ -f $fSource ]; then
     [ $DEBUG == "true" ] && echo "$DATELOG Loading /app/$fSource"
+    # shellcheck source=/dev/null
     . /app/$fSource
   else
     echo "Fatal error; file not found $fSource"
@@ -22,7 +23,6 @@ for fSource in "version.h \
   fi
 done
 ### END Source all required files
-
 
 # If empty string, initialize w/ default value - Required for add-on and Docker standalone
 export BLE_CMD_RETRY_DELAY=${BLE_CMD_RETRY_DELAY:-5}
@@ -34,7 +34,6 @@ export PRESENCE_DETECTION_TTL=${PRESENCE_DETECTION_TTL:-240}
 export BLE_LN_REGEX='S[0-9A-Fa-f]{16}C'
 export MAC_REGEX='([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})'
 export VIN_REGEX='[A-HJ-NPR-Z0-9]{17}'
-
 
 ### LOG CONFIG VARS ###########################################################
 log_info "Configuration Options are:
@@ -52,7 +51,6 @@ log_info "Configuration Options are:
 [ -n "$ENABLE_HA_FEATURES" ] && log_info "  ENABLE_HA_FEATURES=$ENABLE_HA_FEATURES"
 [ -n "$BLECTL_FILE_INPUT" ] && log_info "  BLECTL_FILE_INPUT=$BLECTL_FILE_INPUT"
 
-
 ### SETUP DIRECTORY ###########################################################
 if [ ! -d /share/tesla_ble_mqtt ]; then
   log_info "Creating directory /share/tesla_ble_mqtt"
@@ -60,7 +58,6 @@ if [ ! -d /share/tesla_ble_mqtt ]; then
 else
   log_debug "/share/tesla_ble_mqtt already exists"
 fi
-
 
 ### MQTT clients anonymous or authentication mode #############################
 if [ -n "$MQTT_USERNAME" ]; then
@@ -71,3 +68,4 @@ else
   log_notice "Setting up MQTT clients using anonymous mode"
   export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_SERVER -p $MQTT_PORT"
   export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_SERVER -p $MQTT_PORT"
+fi

--- a/env.sh
+++ b/env.sh
@@ -2,19 +2,19 @@
 #
 # shellcheck shell=dash
 #
+export SW_VERSION=0.1.0
 
 ### LOAD LIBRARIES (FUNCTIONS & ENVIRONMENT ) #################################
-echo "Loading libraries (functions & environment)..."
-for fSource in version.h \
-  product.sh \
-  mqtt.sh \
-  discovery.sh \
+echo "[$(date +%H:%M:%S)] loading libproduct.sh"
+. /app/libproduct.sh
+log_debug "Loading environment & functions..."
+for fSource in discovery.sh \
   listen_to_mqtt.sh \
   subroutines.sh \
   tesla.sh; do
 
-  if [ -f $fSource ]; then
-    [ $DEBUG == "true" ] && echo "$DATELOG Loading /app/$fSource"
+  if [ -f /app/$fSource ]; then
+    log_debug "Loading /app/$fSource"
     # shellcheck source=/dev/null
     . /app/$fSource
   else

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -208,7 +208,7 @@ setup_auto_discovery_loop() {
   for vin in $VIN_LIST; do
 
     # IF HA backend is enable, setup HA Auto Discover
-    if [ "$HA_BACKEND_DISABLE" == "false" ]; then
+    if [ "$ENABLE_HA_FEATURES" == "true" ]; then
       log_debug "Calling setup_auto_discovery() $vin"
       setup_auto_discovery $vin
     else

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -67,8 +67,10 @@ listen_to_mqtt() {
           ;;
 
         scan-bleln-macaddr)
-          log_notice "Scanning for Tesla BLE Local Name and respective MAC addr..."
-          scan-bleln-macaddr
+          log_notice 'scan-bleln-macaddr; calling scanBLEforMACaddr()'
+          if ble_mac_addr=$(scanBLEforMACaddr $vin); then
+            log_notice "Found BLE MAC addr for vin:$vin is $ble_mac_addr"
+          fi
           ;;
 
         *)

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -234,30 +234,6 @@ listen_to_mqtt() {
 }
 
 # Function
-setup_auto_discovery_loop() {
-
-  discardMessages=$1
-
-  # Setup or skip HA auto discovery & Discard old MQTT messages
-  for vin in $VIN_LIST; do
-
-    # IF HA backend is enable, setup HA Auto Discover
-    if [ "$ENABLE_HA_FEATURES" == "true" ]; then
-      log_debug "Calling setup_auto_discovery() $vin"
-      setup_auto_discovery $vin
-    else
-      log_info "HA backend is disable, skipping setup for HA Auto Discovery"
-    fi
-
-    # Discard or not awaiting messages
-    if [ "$discardMessages" = "yes" ]; then
-      log_notice "Discarding any unread MQTT messages for $vin"
-      eval $MOSQUITTO_SUB_BASE -E -i tesla_ble_mqtt -t tesla_ble_mqtt/$vin/+
-    fi
-  done
-}
-
-# Function
 listen_for_HA_start() {
   eval $MOSQUITTO_SUB_BASE --nodelay -t homeassistant/status -F \"%t %p\" |
     while read -r payload; do

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -256,9 +256,9 @@ listenForHAstatus() {
           ;;
         online)
           # Ref: https://github.com/iainbullock/tesla_ble_mqtt_docker/discussions/6
-          log_notice "Home Assistant is now online, calling setup_auto_discovery_loop()"
+          log_notice "Home Assistant is now online, calling setupHADeviceAllVINsLoop()"
           discardMessages=no
-          setup_auto_discovery_loop $discardMessages
+          setupHADeviceAllVINsLoop $discardMessages
           ;;
         *)
           log_error "Invalid status; topic:$topic status:$status"

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -57,7 +57,7 @@ listen_to_mqtt() {
 
         deploy-key)
           log_notice "Trying to deploy the public key to vehicle..."
-          send_key $vin
+          teslaCtrlSendKey $vin
           ;;
 
         scan-bleln-macaddr)
@@ -75,67 +75,67 @@ listen_to_mqtt() {
         case $msg in
         wake)
           log_notice "Waking Up"
-          send_command $vin "-domain vcsec $msg"
+          teslaCtrlSendCommand $vin "-domain vcsec $msg"
           ;;
         trunk-open)
           log_notice "Opening Trunk"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         trunk-close)
           log_notice "Closing Trunk"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         charging-start)
           log_notice "Start Charging"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         charging-stop)
           log_notice "Stop Charging"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         charge-port-open)
           log_notice "Open Charge Port"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         charge-port-close)
           log_notice "Close Charge Port"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         climate-on)
           log_notice "Start Climate"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         climate-off)
           log_notice "Stop Climate"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         flash-lights)
           log_notice "Flash Lights"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         frunk-open)
           log_notice "Open Frunk"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         honk)
           log_notice "Honk Horn"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         lock)
           log_notice "Lock Car"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         unlock)
           log_notice "Unlock Car"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         windows-close)
           log_notice "Close Windows"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         windows-vent)
           log_notice "Vent Windows"
-          send_command $vin $msg
+          teslaCtrlSendCommand $vin $msg
           ;;
         *)
           log_error "Invalid command request; topic:$topic msg:$msg"
@@ -147,13 +147,13 @@ listen_to_mqtt() {
         # https://github.com/iainbullock/tesla_ble_mqtt_docker/issues/4
         if [ $msg -gt 4 ]; then
           log_notice "Set amps"
-          send_command $vin "charging-set-amps $msg"
+          teslaCtrlSendCommand $vin "charging-set-amps $msg"
         else
           log_notice "First Amp set"
-          send_command $vin "charging-set-amps $msg"
+          teslaCtrlSendCommand $vin "charging-set-amps $msg"
           sleep 1
           log_notice "Second Amp set"
-          send_command $vin "charging-set-amps $msg"
+          teslaCtrlSendCommand $vin "charging-set-amps $msg"
         fi
         ;;
 
@@ -161,37 +161,37 @@ listen_to_mqtt() {
         # Command to send a single Amps request
         # Ref: https://github.com/tesla-local-control/tesla_ble_mqtt_core/issues/19
         log_info "Set charging Amps to $msg"
-        send_command $vin "charging-set-amps $msg"
+        teslaCtrlSendCommand $vin "charging-set-amps $msg"
         ;;
 
       charging-set-limit)
-        send_command $vin "charging-set-limit $msg"
+        teslaCtrlSendCommand $vin "charging-set-limit $msg"
         ;;
 
       climate-set-temp)
-        send_command $vin "climate-set-temp ${msg}C"
+        teslaCtrlSendCommand $vin "climate-set-temp ${msg}C"
         ;;
 
       auto-seat-and-climate)
-        send_command $vin "auto-seat-and-climate LR on"
+        teslaCtrlSendCommand $vin "auto-seat-and-climate LR on"
         ;;
 
       heater-seat-front-left)
-        send_command $vin "seat-heater front-left $msg"
+        teslaCtrlSendCommand $vin "seat-heater front-left $msg"
         ;;
 
       heater-seat-front-right)
-        send_command $vin "seat-heater front-right $msg"
+        teslaCtrlSendCommand $vin "seat-heater front-right $msg"
         ;;
 
       steering-wheel-heater)
         msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
-        send_command $vin "steering-wheel-heater $msg_lower"
+        teslaCtrlSendCommand $vin "steering-wheel-heater $msg_lower"
         ;;
 
       sentry-mode)
         msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
-        send_command $vin "sentry-mode $msg_lower"
+        teslaCtrlSendCommand $vin "sentry-mode $msg_lower"
         ;;
 
       *)

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -62,12 +62,8 @@ listen_to_mqtt() {
           ;;
 
         deploy-key)
-          log_debug "deploy-key; calling send_key()"
-          if send_key $vin; then
-            ### TODO add a "checkVehiculeValidKey" using tesla-control list-keys
-            log_info "Setting up Home Assistant device's panel"
-            setupHAAutoDiscovery $vin
-          fi
+          log_debug "deploy-key; calling DeployKey()"
+          DeployKey $vin
           ;;
 
         scan-bleln-macaddr)

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -184,8 +184,14 @@ listen_to_mqtt() {
         send_command $vin "seat-heater front-right $msg"
         ;;
 
-      sw-heater)
-        send_command $vin "sw-heater $msg"
+      steering-wheel-heater)
+        msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
+        send_command $vin "steering-wheel-heater $msg_lower"
+        ;;
+
+      sentry-mode)
+        msg_lower=$(echo "$msg" | tr '[:upper:]' '[:lower:]')
+        send_command $vin "sentry-mode $msg_lower"
         ;;
 
       *)

--- a/listen_to_mqtt.sh
+++ b/listen_to_mqtt.sh
@@ -244,7 +244,7 @@ listen_to_mqtt() {
 }
 
 # Function
-listen_for_HA_start() {
+listenForHAstatus() {
   eval $MOSQUITTO_SUB_BASE --nodelay -t homeassistant/status -F \"%t %p\" |
     while read -r payload; do
       topic=$(echo "$payload" | cut -d ' ' -f 1)

--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ fi
 # If empty string, initialize w/ default value - Required for add-on and Docker standalone
 export BLE_CMD_RETRY_DELAY=${BLE_CMD_RETRY_DELAY:-5}
 export BLECTL_FILE_INPUT=${BLECTL_FILE_INPUT:-}
-export HA_BACKEND_DISABLE=${HA_BACKEND_DISABLE:-false}
+export ENABLE_HA_FEATURES=${ENABLE_HA_FEATURES:-true}
 export PRESENCE_DETECTION_LOOP_DELAY=${PRESENCE_DETECTION_LOOP_DELAY:-120}
 export PRESENCE_DETECTION_TTL=${PRESENCE_DETECTION_TTL:-240}
 
@@ -53,7 +53,7 @@ log_info "Configuration Options are:
   PRESENCE_DETECTION_TTL=$PRESENCE_DETECTION_TTL
   VIN_LIST=$VIN_LIST"
 
-[ -n "$HA_BACKEND_DISABLE" ] && log_info "  HA_BACKEND_DISABLE=$HA_BACKEND_DISABLE"
+[ -n "$ENABLE_HA_FEATURES" ] && log_info "  ENABLE_HA_FEATURES=$ENABLE_HA_FEATURES"
 [ -n "$BLECTL_FILE_INPUT" ] && log_info "  BLECTL_FILE_INPUT=$BLECTL_FILE_INPUT"
 
 # MQTT clients anonymous or authentication mode
@@ -109,7 +109,7 @@ discardMessages=yes
 setup_auto_discovery_loop $discardMessages
 
 # IF HA backend is enable, call listen_for_HA_start()
-if [ "$HA_BACKEND_DISABLE" = "false" ]; then
+if [ "$ENABLE_HA_FEATURES" == "true" ]; then
   log_notice "Listening for Home Assistant Start (in background)"
   listen_for_HA_start &
 else

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@
 # Note: shebang will be replaced automatically by the HA addon deployment script to #!/command/with-contenv bashio
 
 ### DEFINE FUNCTIONS ##########################################################
-echo "[$(date +%H:%M:%S)] Starting, initialize environment..."
+echo "[$(date +%H:%M:%S)] Starting... loading /app/env.sh"
 # Init product's environment
 . /app/env.sh
 

--- a/run.sh
+++ b/run.sh
@@ -58,10 +58,10 @@ fi
 discardMessages=yes
 setupHADeviceAllVINsLoop $discardMessages
 
-# IF HA backend is enable, call listen_for_HA_start()
+# IF HA backend is enable, call listenForHAstatus()
 if [ "$ENABLE_HA_FEATURES" == "true" ]; then
   log_notice "Listening for Home Assistant Start (in background)"
-  listen_for_HA_start &
+  listenForHAstatus &
 else
   log_info "HA backend is disable, not listening for Home Assistant Start"
 fi

--- a/run.sh
+++ b/run.sh
@@ -5,67 +5,9 @@
 # Note: shebang will be replaced automatically by the HA addon deployment script to #!/command/with-contenv bashio
 
 ### DEFINE FUNCTIONS ##########################################################
-echo "Source required files to load required functions"
-### Source required files
-#
-# Source & Init product's library
-[ -f /app/libproduct.sh ] &&
-  echo "Source libproduct.sh" &&
-  . /app/libproduct.sh &&
-  type initProduct >/dev/null &&
-  initProduct
-
-log_debug "Source /app/subroutines.sh"
-. /app/subroutines.sh
-
-log_debug "Source /app/discovery.sh"
-. /app/discovery.sh
-
-log_debug "Source /app/listen_to_mqtt.sh"
-. /app/listen_to_mqtt.sh
-### END Source all required files
-
-### SETUP ENVIRONMENT #########################################################
-if [ ! -d /share/tesla_ble_mqtt ]; then
-  log_info "Creating directory /share/tesla_ble_mqtt"
-  mkdir -p /share/tesla_ble_mqtt
-else
-  log_debug "/share/tesla_ble_mqtt already exists, existing keys can be reused"
-fi
-
-# If empty string, initialize w/ default value - Required for add-on and Docker standalone
-export BLE_CMD_RETRY_DELAY=${BLE_CMD_RETRY_DELAY:-5}
-export BLECTL_FILE_INPUT=${BLECTL_FILE_INPUT:-}
-export ENABLE_HA_FEATURES=${ENABLE_HA_FEATURES:-true}
-export PRESENCE_DETECTION_LOOP_DELAY=${PRESENCE_DETECTION_LOOP_DELAY:-120}
-export PRESENCE_DETECTION_TTL=${PRESENCE_DETECTION_TTL:-240}
-
-### LOG CONFIG VARS ###########################################################
-log_info "Configuration Options are:
-  BLE_CMD_RETRY_DELAY=$BLE_CMD_RETRY_DELAY
-  BLE_MAC_LIST=$BLE_MAC_LIST
-  DEBUG=$DEBUG
-  MQTT_SERVER=$MQTT_SERVER
-  MQTT_PORT=$MQTT_PORT
-  MQTT_PASSWORD=Not Shown
-  MQTT_USERNAME=$MQTT_USERNAME
-  PRESENCE_DETECTION_LOOP_DELAY=$PRESENCE_DETECTION_LOOP_DELAY
-  PRESENCE_DETECTION_TTL=$PRESENCE_DETECTION_TTL
-  VIN_LIST=$VIN_LIST"
-
-[ -n "$ENABLE_HA_FEATURES" ] && log_info "  ENABLE_HA_FEATURES=$ENABLE_HA_FEATURES"
-[ -n "$BLECTL_FILE_INPUT" ] && log_info "  BLECTL_FILE_INPUT=$BLECTL_FILE_INPUT"
-
-# MQTT clients anonymous or authentication mode
-if [ -n "$MQTT_USERNAME" ]; then
-  log_notice "Setting up MQTT clients with authentication"
-  export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_SERVER -p $MQTT_PORT -u '${MQTT_USERNAME}' -P '${MQTT_PASSWORD}'"
-  export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_SERVER -p $MQTT_PORT -u '${MQTT_USERNAME}' -P '${MQTT_PASSWORD}'"
-else
-  log_notice "Setting up MQTT clients using anonymous mode"
-  export MOSQUITTO_PUB_BASE="mosquitto_pub -h $MQTT_SERVER -p $MQTT_PORT"
-  export MOSQUITTO_SUB_BASE="mosquitto_sub -h $MQTT_SERVER -p $MQTT_PORT"
-fi
+echo "[$(date +%H:%M:%S)] Starting, initialize environment..."
+# Init product's environment
+. /app/env.sh
 
 # Replace | with ' ' white space
 BLE_MAC_LIST=$(echo $BLE_MAC_LIST | sed -e 's/[|,;]/ /g')
@@ -79,8 +21,16 @@ for vin in $VIN_LIST; do
   log_debug "Adding $BLE_LN to BLE_LN_LIST, count $vin_count"
   BLE_LN_LIST="$BLE_LN_LIST $BLE_LN"
 
+  if [ -f /share/tesla_ble_mqtt/${vin}_private.pem ] &&
+    [ -f /share/tesla_ble_mqtt/${vin}_public.pem ]; then
+    log_debug "Found public and private keys set for vin:$vin"
+  else
+    log_debug "Did not find public and private keys for vin:$vin"
+  fi
+
   ################ HANDLE CONFIG CHANGE #######################################
-  # TEMPORARY - Move original "vin" key to "vin{1}"
+  ### TODO TEMPORARY - Move original "vin" key to "vin{1}"
+  ###
   if [ -f /share/tesla_ble_mqtt/private.pem ] && [ $vin_count -eq 1 ]; then
     log_warning "Keys exist from a previous installation with single VIN which is deprecated"
     log_warning "This module migrates the key files to attribute them to $vin and remove old MQTT entities"
@@ -126,6 +76,7 @@ while :; do
   listen_to_mqtt_loop &
   # Don't run presence detection if TTL is 0
 
+  # If PRESENCE_DETECTION_TTL > 0 and BLE_MAC_LIST is not empty
   if [ $PRESENCE_DETECTION_TTL -gt 0 ] && [ -n "$BLE_MAC_LIST" ]; then
     log_info "Launch BLE scanning for car presence every $PRESENCE_DETECTION_LOOP_DELAY seconds"
     listen_to_ble $vin_count

--- a/run.sh
+++ b/run.sh
@@ -75,7 +75,7 @@ vin_count=0
 for vin in $VIN_LIST; do
   # Populate BLE Local Names list
   vin_count=$((vin_count + 1))
-  BLE_LN=$(eval tesla_vin2ble_ln $vin)
+  BLE_LN=$(eval vinToBLEln $vin)
   log_debug "Adding $BLE_LN to BLE_LN_LIST, count $vin_count"
   BLE_LN_LIST="$BLE_LN_LIST $BLE_LN"
 

--- a/run.sh
+++ b/run.sh
@@ -56,7 +56,7 @@ fi
 
 # Setup HA auto discovery, or skip if HA backend is disable, and discard old MQTT messages
 discardMessages=yes
-setup_auto_discovery_loop $discardMessages
+setupHADeviceAllVINsLoop $discardMessages
 
 # IF HA backend is enable, call listen_for_HA_start()
 if [ "$ENABLE_HA_FEATURES" == "true" ]; then

--- a/run.sh
+++ b/run.sh
@@ -126,7 +126,7 @@ while :; do
   listen_to_mqtt_loop &
   # Don't run presence detection if TTL is 0
 
-  if [ $PRESENCE_DETECTION_TTL -gt 0 ]; then
+  if [ $PRESENCE_DETECTION_TTL -gt 0 ] && [ -n "$BLE_MAC_LIST" ]; then
     log_info "Launch BLE scanning for car presence every $PRESENCE_DETECTION_LOOP_DELAY seconds"
     listen_to_ble $vin_count
     # Run listen_to_ble every 3m

--- a/subroutines.sh
+++ b/subroutines.sh
@@ -182,7 +182,6 @@ delete_legacies() {
 
 }
 
-
 ### scanBLEforMACaddr
 ##
 #   Uses BLE Local Name derived from the VIN to match a MAC addr in the output

--- a/subroutines.sh
+++ b/subroutines.sh
@@ -181,3 +181,33 @@ delete_legacies() {
   fi
 
 }
+
+
+### scanBLEforMACaddr
+##
+#   Uses BLE Local Name derived from the VIN to match a MAC addr in the output
+##  of the command bluetoothctl "devices" and "scan on"
+###
+scanBLEforMACaddr() {
+  # copied from legacy "scan_bluetooth" function. To decide if still relevant
+  # note there is this PR https://github.com/tesla-local-control/tesla-local-control-addon/pull/32
+  # quite old, but has the principles for auto populating the BLE MAC Address with only the VIN
+  vin=$1
+
+  mac_regex='([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})'
+
+  ble_ln=$(vinToBLEln $vin)
+
+  log_info "Looking for vin:$vin in the BLE cache that matches ble_ln:$ble_ln"
+  if ! bltctl_out=$(bluetoothctl --timeout 2 devices | grep $ble_ln | grep -Eo $mac_regex); then
+    log_notice "Couldn't find a match in the cache for ble_ln:$ble_ln for vin:$vin"
+    # Look for a BLE adverstisement matching ble_ln
+    log_notice "Scanning (10 seconds) for BLE advertisement that matches ble_ln:$ble_ln vin:$vin"
+    if ! bltctl_out=$(bluetoothctl --timeout 10 scan on | grep $ble_ln | grep -Eo $mac_regex); then
+      log_notice "Couldn't find a BLE advertisement for ble_ln:$ble_ln vin:$vin"
+      return 1
+    fi
+  fi
+  echo $bltctl_out
+  return 0
+}

--- a/tesla.sh
+++ b/tesla.sh
@@ -92,20 +92,20 @@ teslaCtrlSendKey() {
 #   Is the car awake?
 ##
 ###
-pingVehicule() {
+pingVehicle() {
   vin=$1
 
-  log_debug "pingVehicule; entering vin:$vin"
+  log_debug "pingVehicle; entering vin:$vin"
 
   if teslaCtrlSendCommand $vin ping "Ping vehicule"; then
-    log_debug "pingVehicule; ping vehicule succeeded vin:$vin"
+    log_debug "pingVehicle; ping vehicule succeeded vin:$vin"
     ret=0
   else
-    log_debug "pingVehicule; Failed to ping vehicule vin:$vin"
+    log_debug "pingVehicle; Failed to ping vehicule vin:$vin"
     ret=2
   fi
 
-  log_debug "pingVehicule; leaving vin:$vin return:$ret"
+  log_debug "pingVehicle; leaving vin:$vin return:$ret"
 
   return $ret
 
@@ -127,7 +127,7 @@ AcceptKeyConfirmationLoop() {
   # Retry loop
   # shellcheck disable=SC1073
   while [ "$(date +%s)" -lt $acceptKeyExpireTime ]; do
-    if pingVehicule $vin; then
+    if pingVehicle $vin; then
       log_info "AcceptKeyConfirmationLoop; congratulation, the public key has been  accepted vin:$vin"
       log_debug "touch /share/tesla_blemqtt/${vin}_pubkey_accepted"
       touch /share/tesla_blemqtt/${vin}_pubkey_accepted

--- a/tesla.sh
+++ b/tesla.sh
@@ -87,6 +87,88 @@ teslaCtrlSendKey() {
   return 1
 }
 
+
+
+###
+##
+#   Is the car awake?
+##
+###
+pingVehicule() {
+  vin=$1
+
+  log_debug "pingVehicule; entering vin:$vin"
+
+  if teslaCtrlCommandOut=$(teslaCtrlSendCommand $vin ping "Ping vehicule"); then
+    log_debug "pingVehicule; ping vehicule vin:$vin succeeded"
+    ret=0
+  else
+    log_debug "pingVehicule; Failed to ping vehicule vin:$vin"
+    ret=2
+  fi
+
+  log_debug "pingVehicule; leaving vin:$vin return:$ret"
+
+  return $ret
+
+}
+
+
+###
+##
+#   Loop for 5 minutes for key to be accepted
+##
+###
+AcceptKeyConfirmationLoop() {
+  vin=$1
+  log_debug "AcceptKeyConfirmationLoop; entering vin:$vin"
+
+  AcceptKeyConfirmationLoopSeconds=300
+  acceptKeyExpireTime=$(($(date +%s) + $AcceptKeyConfirmationLoopSeconds))
+
+  log_info "AcceptKeyConfirmationLoop; check if key was accepted by sending a ping command vin:$vin1"
+  # Retry loop
+  while [ "$(date +%s)" -lt $acceptKeyExpireTime ]; then
+    if pingVehicule $vin; then
+      log_info "AcceptKeyConfirmationLoop; congratulation, the public key has been  accepted vin:$vin"
+      log_debug "touch /share/tesla_blemqtt/${vin}_pubkey_accepted"
+      touch /share/tesla_blemqtt/${vin}_pubkey_accepted
+      log_debug "AcceptKeyConfirmationLoop; leaving vin:$vin ret:0"
+      return 0
+    else
+      log_notice "AcceptKeyConfirmationLoop; sleeping 5 seconds before retrying key vin:$vin1"
+      sleep 5
+    fi
+  done
+  log_debug "AcceptKeyConfirmationLoop; leaving vin:$vin ret:1"
+  return 1
+}
+
+
+###
+##
+#    Send the key to the car then check if it was accepted
+##
+###
+DeployKey() {
+  vin=$1
+
+  log_debug "DeployKey; calling teslaCtrlSendKey()"
+
+  if ! teslaCtrlSendKey $vin; then
+    log_debug "DeployKey; key was not delivered"
+    return 1
+  fi
+
+  log_debug "DeployKey; calling AcceptKeyConfirmationLoop()"
+  if AcceptKeyConfirmationLoop $vin; then
+    log_info "Setting up Home Assistant device's panel"
+    setupHAAutoDiscovery $vin
+  else
+  fi
+
+}
+
 ###
 ##
 #   Tesla VIN to BLE Local Name

--- a/tesla.sh
+++ b/tesla.sh
@@ -1,0 +1,104 @@
+# shellcheck shell=dash
+#
+# tesla.sh
+#
+
+###
+##
+#   teslaCtrlSendCommand
+##
+###
+teslaCtrlSendCommand() {
+  vin=$1
+  command=$2
+  commandDescription=$3
+
+  # shellcheck disable=SC2016
+  TESLA_CONTROL_CMD='/usr/bin/tesla-control -ble -vin $vin -key-name /share/tesla_blemqtt/${vin}_private.pem -key-file /share/tesla_ble_mqtt/${vin}_private.pem $command 2>&1'
+
+  # Retry loop
+  max_retries=5
+  for sendCommandCount in $(seq $max_retries); do
+
+    log_notice "Attempt $sendCommandCount/${max_retries} sending $commandDescription to vin:$vin command:$command"
+    set +e
+    teslaCtrlOut=$(eval $TESLA_CONTROL_CMD)
+    EXIT_STATUS=$?
+    set -e
+    if [ $EXIT_STATUS -eq 0 ]; then
+      log_debug "teslaCtrlSendCommand; $teslaCtrlOut"
+      log_info "Command $command was successfully delivered to vin:$vin"
+      return 0
+    else
+      if [[ "$teslaCtrlOut" == *"car could not execute command"* ]]; then
+        log_warning "teslaCtrlSendCommand; $teslaCtrlOut"
+        log_warning "Skipping command $command to vin:$vin"
+        return 10
+      else
+        log_error "tesla-control send command:$command to vin:$vin failed exit status $EXIT_STATUS."
+        log_error "teslaCtrlSendCommand; $teslaCtrlOut"
+        # Don't continue if we've reached max retries
+        [ $max_retries -eq $sendCommandCount ] &&
+          return 15
+        log_notice "teslaCtrlSendCommand; Retrying in $BLE_CMD_RETRY_DELAY seconds"
+      fi
+      sleep $BLE_CMD_RETRY_DELAY
+    fi
+  done
+
+  # Unreachable
+  return 99
+}
+
+
+###
+##
+#
+##
+###
+teslaCtrlSendKey() {
+  vin=$1
+
+  TESLA_ADD_KEY_CMD='/usr/bin/tesla-control -vin $vin -ble add-key-request /share/tesla_ble_mqtt/${vin}_public.pem owner cloud_key 2>&1'
+
+  log_info "Trying to deploy the public key to vin:$vin"
+
+  max_retries=5
+  for sendKeyCount in $(seq $max_retries); do
+    log_notice "Attempt $sendKeyCount/${max_retries} to delivery the public key to vin $vin"
+    set +e
+    teslaCtrlOut=$(eval $TESLA_ADD_KEY_CMD)
+    EXIT_STATUS=$?
+    set -e
+    if [ $EXIT_STATUS -eq 0 ]; then
+      log_debug "teslaCtrlSendKey; $teslaCtrlOut"
+      log_warning "KEY DELIVERED; IN YOUR CAR, CHECK THE CAR's CENTRAL SCREEN AND ACCEPT THE KEY USING YOUR NFC CARD"
+      return 0
+    else
+      log_error "teslaCtrlSendKey; $teslaCtrlOut"
+      log_error "Could not send the key; Is the car awake and sufficiently close to the bluetooth adapter?"
+      # Don't continue if we've reached max retries
+      [ $max_retries -eq $sendKeyCount ] &&
+        return 15
+      log_notice "teslaCtrlSendKey; Retrying in $BLE_CMD_RETRY_DELAY seconds"
+      sleep $BLE_CMD_RETRY_DELAY
+    fi
+  done
+  return 1
+}
+
+###
+##
+#   Tesla VIN to BLE Local Name
+##
+###
+function vinToBLEln() {
+  vin=$1
+  ble_ln=""
+
+  # BLE Local Name
+  ble_ln="S$(echo -n ${vin} | sha1sum | cut -c 1-16)C"
+
+  echo $ble_ln
+
+}

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,5 @@
+#!/bin/ash
+#
+# shellcheck shell=dash
+#
+export SW_VERSION=0.0.10f


### PR DESCRIPTION
smarter DeployKey & Device's Card Panel logic
  - Cards in Device's Panel shows up when needed
  - tesla.sh added : DeployKey; AcceptKeyConfirmationLoop; pingVehicle

Rename listen_for_HA_start->listenForHAstatus

Listen_to_mqtt; use new teslaCtrlSendCommand

Split setup_auto_discovery:
  Create following functions:
    - setupHADeviceEnvVars
    - setupHADevicePanelCardsMain
    - setupHADeviceControlsCard
    - setupHADeviceGenerateKeysButton
    - setupHADevicePresenceSenso
    - setupHADeviceDeployKeyButton
    - setupHADeviceScanBLElnButton
    - setupHADeviceAllVINsLoop

listen_to_mqtt: sort & add missing commands

Create env.sh & version.sh, move top of run.sh to env.sh

  - Add logging if keys set found or not for a VIN

Create tesla.sh & update functions

  - pass commandDescription from listen_mqtt
  - add return value
  - add more logging/consistancy (debug/info)
  - rename send_key -> teslaCtrlSendKey*
  - rename send_command -> teslaCtrlSendCommand*
  - rename tesla_vin2ble_ln -> vinToBLEln

  * in case someday teslaAPISendCommand