### PR TITLE
[feat] Info Bluetooth Adapter

### DIFF
--- a/mqtt-discovery.sh
+++ b/mqtt-discovery.sh
@@ -57,13 +57,13 @@ function setupHADevicePanelCardsMain() {
     setupHADeviceDeployKeyButton $vin
     setupHADeviceGenerateKeysButton $vin
     setupHADeviceControlsCard $vin
-    setupHADeviceScanBLElnButton $vin
+    setupHADeviceInfoBTadapter $vin
   elif [ ! -f $KEYS_DIR/${vin}_private.pem ] && [ ! -f $KEYS_DIR/${vin}_public.pem ]; then
 
     log_debug "setupHADevicePanelCardsMain() found new vehicle, need to generate keys set vin:$vin"
     # Show button to Generate Keys
     setupHADeviceGenerateKeysButton $vin
-    setupHADeviceScanBLElnButton $vin
+    setupHADeviceInfoBTadapter $vin
 
     # listen_to_mqtt call setupHADeviceDeployKeyButton once the keys are generated
 
@@ -71,7 +71,7 @@ function setupHADevicePanelCardsMain() {
     log_debug "setupHADevicePanelCardsMain() found new vehicle, need to deploy public key vin:$vin"
     setupHADeviceDeployKeyButton $vin
     setupHADeviceGenerateKeysButton $vin
-    setupHADeviceScanBLElnButton $vin
+    setupHADeviceInfoBTadapter $vin
   fi
 
   log_debug "setupHADevicePanelCardsMain() leaving vin:$vin"
@@ -640,10 +640,10 @@ function setupHADeviceDeployKeyButton() {
 #   Setup Scan BLE LN Button
 ##
 ###
-function setupHADeviceScanBLElnButton() {
+function setupHADeviceInfoBTadapter() {
   vin=$1
 
-  log_debug "setupHADeviceScanBLElnButton() entering vin:$vin"
+  log_debug "setupHADeviceInfoBTadapter() entering vin:$vin"
   configHADeviceEnvVars $vin
 
   echo '{
@@ -658,14 +658,14 @@ function setupHADeviceScanBLElnButton() {
     "sw_version": "'${SW_VERSION}'"
    },
    "device_class": "update",
-   "name": "Scan Bluetooth",
-   "payload_press": "scan-bleln-macaddr",
+   "name": "Info Bluetooth Adapter",
+   "payload_press": "info-bt-adapter",
    "qos": "'${QOS_LEVEL}'",
-   "unique_id": "'${DEV_ID}'_scan-bleln-macaddr",
+   "unique_id": "'${DEV_ID}'_info-bt-adapter",
    "entity_category": "diagnostic"
-  }' | sed ':a;N;$!ba;s/\n//g' | retryMQTTpub -t homeassistant/button/${DEV_ID}/scan-bleln-macaddr/config -l
+  }' | sed ':a;N;$!ba;s/\n//g' | retryMQTTpub -t homeassistant/button/${DEV_ID}/info-bt-adapter/config -l
 
-  log_debug "setupHADeviceScanBLElnButton() leaving vin:$vin"
+  log_debug "setupHADeviceInfoBTadapter() leaving vin:$vin"
 
 }
 

--- a/mqtt-listen.sh
+++ b/mqtt-listen.sh
@@ -66,11 +66,9 @@ listen_to_mqtt() {
           deployKeyMain $vin
           ;;
 
-        scan-bleln-macaddr)
-          log_notice 'scan-bleln-macaddr; calling scanBLEforMACaddr()'
-          if ble_mac_addr=$(scanBLEforMACaddr $vin); then
-            log_notice "Found BLE MAC addr for vin:$vin is $ble_mac_addr"
-          fi
+        info-bt-adapter)
+          log_notice 'info-bt-adapter; launching infoBluetoothAdapter(); results in ~10 seconds"'
+          infoBluetoothAdapter $vin
           ;;
 
         *)

--- a/subroutines.sh
+++ b/subroutines.sh
@@ -140,31 +140,40 @@ listen_to_ble() {
   done
 }
 
-### scanBLEforMACaddr
+### infoBluetoothAdapter
 ##
-#   Uses BLE Local Name derived from the VIN to match a MAC addr in the output
-##  of the command bluetoothctl "devices" and "scan on"
+#   Get Bluetooth adapter information for diagnostic
+##  Note: scan on in bltctlCommands must be the last command.
 ###
-scanBLEforMACaddr() {
-  # copied from legacy "scan_bluetooth" function. To decide if still relevant
-  # note there is this PR https://github.com/tesla-local-control/tesla-local-control-addon/pull/32
-  # quite old, but has the principles for auto populating the BLE MAC Address with only the VIN
-  vin=$1
+infoBluetoothAdapter() {
 
-  mac_regex='([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})'
+  log_debug "Launching bluetoothctl to check for BLE presence"
+  set +e
+  BLTCTL_OUT=$({
+    bltctlCommands="version,list,show,menu mgmt,info,back,power on,scan on"
+    IFS=','
+    for bltctlCommand in $bltctlCommands; do
+      echo "##################################################################"
+      echo "$bltctlCommand"
+      sleep 0.2
+    done
 
-  ble_ln=$(vinToBLEln $vin)
+    # scan for 10 seconds (Tesla adverstisement each ~9s)
+    sleep 10
 
-  log_info "Looking for vin:$vin in the BLE cache that matches ble_ln:$ble_ln"
-  if ! bltctl_out=$(bluetoothctl --timeout 2 devices | grep $ble_ln | grep -Eo $mac_regex); then
-    log_notice "Couldn't find a match in the cache for ble_ln:$ble_ln for vin:$vin"
-    # Look for a BLE adverstisement matching ble_ln
-    log_notice "Scanning (10 seconds) for BLE advertisement that matches ble_ln:$ble_ln vin:$vin"
-    if ! bltctl_out=$(bluetoothctl --timeout 10 scan on | grep $ble_ln | grep -Eo $mac_regex); then
-      log_notice "Couldn't find a BLE advertisement for ble_ln:$ble_ln vin:$vin"
-      return 1
-    fi
+    echo "scan off"
+    echo "exit"
+  } | bluetoothctl | sed -r 's/\x1b\[[0-9;]*m//g' | grep -E '(^Version|bluetooth)')
+  set -e
+
+  log_notice "\n# INFO BLUETOOTH ADAPTER\n$BLTCTL_OUT\n##################################################################"
+
+  bltctlVersion=$(echo "$BLTCTL_OUT" | grep ^Version | sed -e 's/^Version //g')
+  bltctlMinVersion=5.63
+  if awk -v n1="$bltctlMinVersion" -v n2="$bltctlVersion" 'BEGIN {exit !(n1 > n2)}'; then
+    log_warning "Minimum recommended version of Bluez:$bltctlMinVersion; your system version:$bltctlVersion"
+  else
+    log_debug "Minimum recommended version of Bluez:$bltctlMinVersion; your system version:$bltctlVersion"
   fi
-  echo $bltctl_out
-  return 0
+
 }


### PR DESCRIPTION
It runs the following commands:

- version -> `BlueZ >= 5.63 as older versions have been reported to be unreliable` ref: https://www.home-assistant.io/integrations/bluetooth/
- list (adapters)
- show (adapter status)
- menu mgmt
- info (more info)
- power on
- scan on

This replaces the previous scan-ble-macaddr