### PR TITLE
Fix charging set amps log

### DIFF
--- a/mqtt-listen.sh
+++ b/mqtt-listen.sh
@@ -145,7 +145,7 @@ listen_to_mqtt() {
         if [ $msg -gt 4 ]; then
           teslaCtrlSendCommand $vin "charging-set-amps $msg" "Set charging Amps to $msg"
         else
-          teslaCtrlSendCommand $vin "charging-set-amps $msg" "4A or less requested, calling charging-set-amps twice $msg"
+          teslaCtrlSendCommand $vin "charging-set-amps $msg" "4A or less requested, calling charging-set-amps $msg twice"
           sleep 1
           teslaCtrlSendCommand $vin "charging-set-amps $msg" "Set charging Amps to $msg"
         fi

--- a/mqtt-listen.sh
+++ b/mqtt-listen.sh
@@ -145,7 +145,7 @@ listen_to_mqtt() {
         if [ $msg -gt 4 ]; then
           teslaCtrlSendCommand $vin "charging-set-amps $msg" "Set charging Amps to $msg"
         else
-          teslaCtrlSendCommand $vin "charging-set-amps $msg" "Set charging Amps to 5A then to $msg"
+          teslaCtrlSendCommand $vin "charging-set-amps $msg" "4A or less requested, calling charging-set-amps twice $msg"
           sleep 1
           teslaCtrlSendCommand $vin "charging-set-amps $msg" "Set charging Amps to $msg"
         fi

--- a/mqtt-listen.sh
+++ b/mqtt-listen.sh
@@ -39,6 +39,10 @@ listen_to_mqtt() {
       config)
 
         case $msg in
+        body-controller-state)
+          teslaCtrlSendCommand $vin $msg "Fetch limited vehicle state information. Works over BLE when infotainment is asleep"
+          ;;
+
         generate-keys)
           log_notice "Generating the private key..."
           openssl ecparam -genkey -name prime256v1 -noout >$KEYS_DIR/${vin}_private.pem
@@ -82,9 +86,6 @@ listen_to_mqtt() {
         case $msg in
         autosecure-modelx)
           teslaCtrlSendCommand $vin $msg "Close falcon-wing doors and lock vehicle"
-          ;;
-        body-controller-state)
-          teslaCtrlSendCommand $vin $msg "Fetch limited vehicle state information. Works over BLE when infotainment is asleep"
           ;;
         charging-schedule-cancel)
           teslaCtrlSendCommand $vin $msg "Cancel scheduled charge start"


### PR DESCRIPTION
Thanks for this great project, works pretty well for me! 😃 
One thing that confused me was this line in the logs:
`sending Set charging Amps to 5A then to 3 to vin:ASDF1234567890 command:charging-set-amps 3` since I did not request 5A charging current. Checking the source revealed that only logs are confusing and everything works as expected. So this PR improves on logging so others might end up less confused. 😂 