### PR TITLE
Wake in case of command failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.2
+
+### Changed
+
+- NEW Feature: Try to wake car if command fails with "Error: context deadline exceeded"
+
 ## 0.2.1
 
 ### <p>**WARNING WARNING WARNING**<br>

--- a/env.sh
+++ b/env.sh
@@ -2,7 +2,7 @@
 #
 # shellcheck shell=dash
 #
-export SW_VERSION=0.2.0
+export SW_VERSION=0.2.2
 
 ### LOAD LIBRARIES (FUNCTIONS & ENVIRONMENT ) #################################
 echo "[$(date +%H:%M:%S)] loading libproduct.sh"

--- a/tesla-commands.sh
+++ b/tesla-commands.sh
@@ -45,6 +45,7 @@ teslaCtrlSendCommand() {
         # TODO check that this situation appears only once (or few)
         # to avoid getting into a loop if we cannot wake the car
         # if this happen the "else" will never be triggered and the command will never exit
+        # would be possible to parse the return code of teslaCtrlSendCommand to check that wake succeeded
       else
         log_error "tesla-control send command:$command to vin:$vin failed exit status $EXIT_STATUS."
         log_error "teslaCtrlSendCommand; $teslaCtrlOut"

--- a/tesla-commands.sh
+++ b/tesla-commands.sh
@@ -37,6 +37,14 @@ teslaCtrlSendCommand() {
         log_warning "teslaCtrlSendCommand; $teslaCtrlOut"
         log_warning "Skipping command $command to vin:$vin"
         return 10
+      elif [[ "$teslaCtrlOut" == *"context deadline exceeded"* ]]; then
+        log_warning "teslaCtrlSendCommand; $teslaCtrlOut"
+        log_warning "Vehicle might be asleep"
+        log_notice "Trying to wake up car then launch the command again"
+        teslaCtrlSendCommand $vin "-domain vcsec wake" "Wake up vehicule"
+        # TODO check that this situation appears only once (or few)
+        # to avoid getting into a loop if we cannot wake the car
+        # if this happen the "else" will never be triggered and the command will never exit
       else
         log_error "tesla-control send command:$command to vin:$vin failed exit status $EXIT_STATUS."
         log_error "teslaCtrlSendCommand; $teslaCtrlOut"

--- a/tesla-commands.sh
+++ b/tesla-commands.sh
@@ -9,10 +9,23 @@
 ##
 ###
 teslaCtrlSendCommand() {
+  # Process in case of nested call (autowake)
+  if [ $# -eq 4 ]; then
+    log_debug "teslaCtrlSendCommand; Nested call: in. Set callMode and copy internal variables"
+    vin_previous=$vin
+    command_previous=$command
+    commandDescription_previous=$commandDescription
+    callMode="nested"
+  else
+    log_debug "teslaCtrlSendCommand; Standard call: in."
+    callMode="standard"
+  fi
+  # Set internal variables
   vin=$1
   command=$2
   commandDescription=$3
 
+  # Prepare for calling tesla-control
   export TESLA_VIN=$vin
   export TESLA_KEY_FILE=$KEYS_DIR/${vin}_private.pem
   export TESLA_KEY_NAME=$KEYS_DIR/${vin}_private.pem
@@ -31,6 +44,16 @@ teslaCtrlSendCommand() {
     if [ $EXIT_STATUS -eq 0 ]; then
       log_debug "teslaCtrlSendCommand; $teslaCtrlOut"
       log_info "Command $command was successfully delivered to vin:$vin"
+      # Finalize in case of nested call (autowake)
+      if [[ "$callMode" == "nested" ]]; then
+        log_debug "teslaCtrlSendCommand; Nested call: out. Set callMode back to standard and revert internal variables"
+        vin=$vin_previous
+        command=$command_previous
+        commandDescription=$commandDescription_previous
+        callMode="standard"
+      else
+        log_debug "teslaCtrlSendCommand; Standard call: out."
+      fi
       return 0
     else
       if [[ "$teslaCtrlOut" == *"car could not execute command"* ]]; then
@@ -38,14 +61,15 @@ teslaCtrlSendCommand() {
         log_warning "Skipping command $command to vin:$vin"
         return 10
       elif [[ "$teslaCtrlOut" == *"context deadline exceeded"* ]]; then
-        log_warning "teslaCtrlSendCommand; $teslaCtrlOut"
-        log_warning "Vehicle might be asleep"
-        log_notice "Trying to wake up car then launch the command again"
-        teslaCtrlSendCommand $vin "-domain vcsec wake" "Wake up vehicule"
         # TODO check that this situation appears only once (or few)
         # to avoid getting into a loop if we cannot wake the car
         # if this happen the "else" will never be triggered and the command will never exit
-        # would be possible to parse the return code of teslaCtrlSendCommand to check that wake succeeded
+        log_debug "teslaCtrlSendCommand; txt deadline exc. - IN"
+        log_warning "teslaCtrlSendCommand; $teslaCtrlOut"
+        log_warning "Vehicle might be asleep"
+        log_notice "Trying to wake up car then launch the command again"
+        teslaCtrlSendCommand $vin "-domain vcsec wake" "Wake up vehicule" "internal"
+        log_debug "teslaCtrlSendCommand; txt deadline exc. - OUT"
       else
         log_error "tesla-control send command:$command to vin:$vin failed exit status $EXIT_STATUS."
         log_error "teslaCtrlSendCommand; $teslaCtrlOut"


### PR DESCRIPTION
Simple quick and not so dirty:
- Add condition to parse the output of `tesla-control` command, filtering on `Error: context deadline exceeded`
- Launch nested wake to try and wake up the car

closes #119 
closes https://github.com/tesla-local-control/tesla-local-control-addon/issues/104
