### PR TITLE
Fix climate-set-temp autodiscovery for ºF

### DIFF
--- a/mqtt-discovery.sh
+++ b/mqtt-discovery.sh
@@ -416,7 +416,7 @@ function setupExtendedControls() {
       "max": "83",
       "mode": "slider",
       "qos": "'${QOS_LEVEL}'",
-      "unique_id": "'${DEVICE_ID}'_climate-set-temp",
+      "unique_id": "'${DEVICE_ID}'_climate-set-temp"
     }' | sed ':a;N;$!ba;s/\n//g' | retryMQTTpub 6 10 -t homeassistant/number/${DEVICE_ID}/climate-temp/config -l
 
   else


### PR DESCRIPTION
Remove trailing comma in config payload which prevents number entity from appearing by HA discovery.