### PR TITLE
Fix climate-set-temp

### DIFF
--- a/mqtt-listen.sh
+++ b/mqtt-listen.sh
@@ -162,7 +162,8 @@ listen_to_mqtt() {
         ;;
 
       climate-set-temp)
-        [ ${msg} -le 50 ] && T="${msg}ºC" || T="${msg}ºF"
+        [ ${msg} -le 50 ] && T="${msg}°C" || T="${msg}°F"
+        [ ${msg} -le 50 ] && msg="${msg}F" || msg="${msg}C"
         teslaCtrlSendCommand $vin "climate-set-temp $msg" "Set climate temperature to ${T}"
         ;;
 

--- a/mqtt-listen.sh
+++ b/mqtt-listen.sh
@@ -163,7 +163,7 @@ listen_to_mqtt() {
 
       climate-set-temp)
         [ ${msg} -le 50 ] && T="${msg}°C" || T="${msg}°F"
-        [ ${msg} -le 50 ] && msg="${msg}F" || msg="${msg}C"
+        [ ${msg} -le 50 ] && msg="${msg}C" || msg="${msg}F"
         teslaCtrlSendCommand $vin "climate-set-temp $msg" "Set climate temperature to ${T}"
         ;;
 


### PR DESCRIPTION
Fix degree symbol and ensure that F or C is appended to the temperature when calling teslaCtrlSendCommand. This should fully resolve https://github.com/tesla-local-control/tesla_ble_mqtt_docker/issues/61