### PR TITLE
Iain dev

### DIFF
--- a/read-state.sh
+++ b/read-state.sh
@@ -308,15 +308,12 @@ function getStateValueAndPublish() {
       esac
     fi
 
-
     # Modify values in specific cases
-    # getStateValueAndPublish $vin '.climateState.driverTempSetting' number/driver_temp_setting "$TESLACTRLOUT" &&
     if [[ $jsonParam == ".climateState.driverTempSetting" && $TEMPERATURE_UNIT_FAHRENHEIT == "true" ]]; then
       log_debug "Converting C to F for Climate Temp State"
       rqdValue=`echo "1.8 * $rqdValue + 32" | bc`
       rqdValue=${rqdValue%.*} 
     fi
-
 
     # Modify values in specific cases
     if [ $jsonParam == ".closuresState.sentryModeState" ]; then

--- a/read-state.sh
+++ b/read-state.sh
@@ -308,6 +308,16 @@ function getStateValueAndPublish() {
       esac
     fi
 
+
+    # Modify values in specific cases
+    # getStateValueAndPublish $vin '.climateState.driverTempSetting' number/driver_temp_setting "$TESLACTRLOUT" &&
+    if [[ $jsonParam == ".climateState.driverTempSetting" && $TEMPERATURE_UNIT_FAHRENHEIT == "true" ]]; then
+      log_debug "Converting C to F for Climate Temp State"
+      rqdValue=`echo "1.8 * $rqdValue + 32" | bc`
+      rqdValue=${rqdValue%.*} 
+    fi
+
+
     # Modify values in specific cases
     if [ $jsonParam == ".closuresState.sentryModeState" ]; then
       rqdValue=$(echo $rqdValue | jq '.Off')


### PR DESCRIPTION
Fix issue when TEMPERATURE_UNIT_FAHRENHEIT is `true`.

When `TEMPERATURE_UNIT_FAHRENHEIT=true` the [Climate Temp number entity](https://github.com/tesla-local-control/tesla_ble_mqtt_core/blob/28464755352cef26496cd4fef3db67ca20e5a197/mqtt-discovery.sh#L428) expects a range of 57-83. When `.climateState.driverTempSetting` which populates the Climate Temp entity is returned it is done so in Celsius and is not in the valid range. We must convert to Fahrenheit or else the Climate Temp entity will be "Unknown".

Before change and after are shown:
![Screen Shot 2025-01-10 at 1 41 41 PM](https://github.com/user-attachments/assets/a9da4acd-7364-43f8-b875-7e6b441f94e1)
