### PR TITLE
Wake up car requires key to be deployed

### DIFF
--- a/mqtt-discovery-sensors.sh
+++ b/mqtt-discovery-sensors.sh
@@ -32,11 +32,11 @@ function setupPresenceSensor {
 
 }
 
-# Charge State Sensors
-function setupChargeStateSensors {
+# Setup remaining sensors
+function setupStateSensors {
   vin=$1
 
-  log_debug "setupChargeStateSensors() entering vin:$vin"
+  log_debug "setupStateSensors() entering vin:$vin"
   configHADeviceEnvVars $vin
 
   echo '{
@@ -773,6 +773,6 @@ function setupChargeStateSensors {
   #  "unique_id": "'${DEVICE_ID}'_charge_port_latch"
   # }' | sed ':a;N;$!ba;s/\n//g' | retryMQTTpub 36 10 -t homeassistant/binary_sensor/${DEVICE_ID}/charge_port_latch/config -l
 
-  log_debug "setupChargeStateSensors() leaving vin:$vin"
+  log_debug "setupStateSensors() leaving vin:$vin"
 
 }

--- a/mqtt-discovery.sh
+++ b/mqtt-discovery.sh
@@ -115,7 +115,7 @@ teslaControlCommands="\
 1,C,tonneau-open,mdi:shutter,Open Cybertruck tonneau
 1,C,tonneau-stop,mdi:shutter,Stop moving Cybertruck tonneau
 1,*,unlock,mdi:lock-open,Unlock car
-0,*,wake,mdi:hand-wave,Wake up car"
+1,*,wake,mdi:hand-wave,Wake up car"
 
 generateCommandJson() {
   UNIQUE_ID=$1

--- a/mqtt-discovery.sh
+++ b/mqtt-discovery.sh
@@ -58,9 +58,6 @@ function setupPanelMain() {
 
   fi
 
-  # Setup Charge State Sensors
-  setupChargeStateSensors $vin
-
   # Newly added car?
   if [ -f $KEYS_DIR/${vin}_pubkey_accepted ]; then
     log_debug "setupPanelMain() found vehicle with pubkey deployed vin:$vin"
@@ -69,6 +66,7 @@ function setupPanelMain() {
     setupDiagnostic $vin
     setupButtonControls $vin 1
     setupExtendedControls $vin
+    setupStateSensors $vin
   elif [ ! -f $KEYS_DIR/${vin}_private.pem ] && [ ! -f $KEYS_DIR/${vin}_public.pem ]; then
 
     log_debug "setupPanelMain() found new vehicle, need to generate keys set vin:$vin"


### PR DESCRIPTION
```
[14:17:43] NOTICE: Attempt 1/5 sending Wake up vehicule to vin:5YJ3E1EB6JFXXXXXX command:-domain vcsec wake
[14:17:46] ERROR: tesla-control send command:-domain vcsec wake to vin:5YJ3E1EB6JFXXXXXX failed exit status 1.
[14:17:46] ERROR: teslaCtrlSendCommand; 2025/02/01 14:17:43 Using Bluetooth adapter: hci0
Error: vehicle rejected request: your public key has not been paired with the vehicle
```